### PR TITLE
Remove use of internal= and fix authentication in search

### DIFF
--- a/ssha.mjs
+++ b/ssha.mjs
@@ -1,41 +1,32 @@
 import crypto from 'crypto'
 
 export default class {
-  static ssha_pass(passwd, salt, next) {
-    const _ssha = (passwd, salt, next ) => {
+  static async ssha_pass(passwd, salt) {
+    const _ssha = (passwd, salt) => {
         const ctx = crypto.createHash('sha1');
         ctx.update(passwd, 'utf-8');
         ctx.update(salt, 'binary');
         const digest = ctx.digest('binary');
         const ssha = '{ssha}' + new Buffer(digest+salt,'binary').toString('base64');
-        return next(null, ssha);
+        return ssha;
     }
-    if(next === undefined) {
-            next = salt;
-            salt = null;
+    if(salt === undefined || salt === null) {
+      let buf = await crypto.RandomBytes(32);
+      return _ssha(passwd, buf.toString('base64'));
+    } else {
+      return _ssha(passwd, salt);
     }
-    if(salt === null ){
-        crypto.randomBytes(32, function(ex, buf) {
-            if (ex) return next(ex);
-            _ssha(passwd,buf.toString('base64') ,next);
-            return null;
-        });
-    }else{
-        _ssha(passwd,salt,next);
-    }
-    return null;
   }
 
-  static checkssha(passwd, hash, next) {
+  static async checkssha(passwd, hash) {
     if (hash.substring(0,6).toLowerCase() != '{ssha}') {
-        return next(new Error('not {ssha}'),false);
+        throw new Error('not {ssha}');
     }
     const bhash = new Buffer(hash.substr(6),'base64');
     const salt = bhash.toString('binary',20); // sha1 digests are 20 bytes long
-    this.ssha_pass(passwd,salt,function(err,newssha){
-        if(err) return next(err)
-        return next(null,hash.substring(6) === newssha.substring(6))
-    });
-    return null;
+
+    let newssha = await this.ssha_pass(passwd, salt);
+    
+    return (hash.substring(6) === newssha.substring(6));
   }
 }


### PR DESCRIPTION
There were references to `internal=` kinds of values but they were created as `attribute=` by the part that creates the initial admin so i assumed `internal=` is legacy and removed it to use `attribute=` everywhere. In particular, fixed `internal=permission` in authorized to be `attribute=permissions`, the actual value that was created in the db.